### PR TITLE
Align backend hreflang and canonical urls

### DIFF
--- a/app/code/Horizon/HreflangGraphQl/Helper/AlternateUrlHelper.php
+++ b/app/code/Horizon/HreflangGraphQl/Helper/AlternateUrlHelper.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Copyright © Horizon. All rights reserved.
+ */
+declare(strict_types=1);
+
+namespace Horizon\HreflangGraphQl\Helper;
+
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Api\StoreRepositoryInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\UrlInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Helper class for generating alternate URLs across stores
+ */
+class AlternateUrlHelper
+{
+    /**
+     * @var StoreRepositoryInterface
+     */
+    private $storeRepository;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param StoreRepositoryInterface $storeRepository
+     * @param StoreManagerInterface $storeManager
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        StoreRepositoryInterface $storeRepository,
+        StoreManagerInterface $storeManager,
+        LoggerInterface $logger
+    ) {
+        $this->storeRepository = $storeRepository;
+        $this->storeManager = $storeManager;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Get alternate URLs for all stores where the entity is available
+     *
+     * @param callable $urlGenerator Callback function that generates URL for a given store
+     * @param int|null $currentStoreId Current store ID
+     * @return array Array of alternate URLs with hreflang tags
+     */
+    public function getAlternateUrls(callable $urlGenerator, ?int $currentStoreId = null): array
+    {
+        $alternateUrls = [];
+        
+        try {
+            $stores = $this->storeRepository->getList();
+            $currentStoreId = $currentStoreId ?? $this->storeManager->getStore()->getId();
+            
+            foreach ($stores as $store) {
+                /** @var StoreInterface $store */
+                if (!$store->isActive()) {
+                    continue;
+                }
+                
+                try {
+                    // Generate URL for this store
+                    $url = $urlGenerator($store);
+                    
+                    if (empty($url)) {
+                        continue;
+                    }
+                    
+                    // Get locale code for hreflang
+                    $locale = $this->getLocaleCode($store);
+                    
+                    $alternateUrls[] = [
+                        'hreflang' => $locale,
+                        'url' => $url
+                    ];
+                } catch (\Exception $e) {
+                    // Log but continue with other stores
+                    $this->logger->warning(
+                        sprintf(
+                            'Failed to generate alternate URL for store %s: %s',
+                            $store->getCode(),
+                            $e->getMessage()
+                        )
+                    );
+                    continue;
+                }
+            }
+        } catch (\Exception $e) {
+            $this->logger->error(
+                sprintf('Failed to retrieve stores for alternate URLs: %s', $e->getMessage())
+            );
+        }
+        
+        return $alternateUrls;
+    }
+
+    /**
+     * Get locale code for hreflang tag
+     *
+     * @param StoreInterface $store
+     * @return string
+     */
+    private function getLocaleCode(StoreInterface $store): string
+    {
+        try {
+            $locale = $store->getLocaleCode();
+            // Convert locale format if needed (e.g., 'en_US' to 'en-US')
+            return str_replace('_', '-', $locale);
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                sprintf('Failed to get locale for store %s: %s', $store->getCode(), $e->getMessage())
+            );
+            // Fallback to store code if locale is not available
+            return $store->getCode();
+        }
+    }
+
+    /**
+     * Generate relative URL for a product in a specific store
+     *
+     * @param \Magento\Catalog\Model\Product $product
+     * @param StoreInterface $store
+     * @return string|null
+     */
+    public function getProductUrl(\Magento\Catalog\Model\Product $product, StoreInterface $store): ?string
+    {
+        try {
+            // Check if product is available in this store
+            $websiteIds = $product->getWebsiteIds();
+            if (!in_array($store->getWebsiteId(), $websiteIds)) {
+                return null;
+            }
+            
+            $originalStoreId = $this->storeManager->getStore()->getId();
+            $this->storeManager->setCurrentStore($store->getId());
+            
+            // Set store context and generate URL
+            $product->setStoreId($store->getId());
+            $product->getUrlModel()->getUrl($product, ['_ignore_category' => true]);
+            $url = $product->getRequestPath();
+            
+            $this->storeManager->setCurrentStore($originalStoreId);
+            
+            return $url;
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                sprintf(
+                    'Failed to generate product URL for store %s: %s',
+                    $store->getCode(),
+                    $e->getMessage()
+                )
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Generate relative URL for a category in a specific store
+     *
+     * @param \Magento\Catalog\Model\Category $category
+     * @param StoreInterface $store
+     * @return string|null
+     */
+    public function getCategoryUrl(\Magento\Catalog\Model\Category $category, StoreInterface $store): ?string
+    {
+        try {
+            // Check if category is available in this store
+            $storeIds = $category->getStoreIds();
+            if (!in_array($store->getId(), $storeIds) && !in_array(0, $storeIds)) {
+                return null;
+            }
+            
+            $originalStoreId = $this->storeManager->getStore()->getId();
+            $this->storeManager->setCurrentStore($store->getId());
+            
+            // Set store context and generate URL
+            $category->setStoreId($store->getId());
+            $baseUrl = $category->getUrlInstance()->getBaseUrl();
+            $fullUrl = $category->getUrl();
+            
+            $this->storeManager->setCurrentStore($originalStoreId);
+            
+            if ($fullUrl !== null) {
+                return str_replace($baseUrl, '', $fullUrl);
+            }
+            
+            return null;
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                sprintf(
+                    'Failed to generate category URL for store %s: %s',
+                    $store->getCode(),
+                    $e->getMessage()
+                )
+            );
+            return null;
+        }
+    }
+
+    /**
+     * Generate relative URL for a CMS page in a specific store
+     *
+     * @param \Magento\Cms\Api\Data\PageInterface $page
+     * @param StoreInterface $store
+     * @return string|null
+     */
+    public function getCmsPageUrl(\Magento\Cms\Api\Data\PageInterface $page, StoreInterface $store): ?string
+    {
+        try {
+            $identifier = $page->getIdentifier();
+            if (empty($identifier)) {
+                return null;
+            }
+            
+            // Check if page is available in this store
+            $storeIds = $page->getStoreId();
+            if ($storeIds !== null && $storeIds !== '0') {
+                $storeIdsArray = is_array($storeIds) ? $storeIds : explode(',', (string)$storeIds);
+                if (!in_array($store->getId(), $storeIdsArray) && !in_array('0', $storeIdsArray)) {
+                    return null;
+                }
+            }
+            
+            // CMS pages typically use their identifier as URL key
+            // Return relative URL path
+            return '/' . $identifier;
+        } catch (\Exception $e) {
+            $this->logger->warning(
+                sprintf(
+                    'Failed to generate CMS page URL for store %s: %s',
+                    $store->getCode(),
+                    $e->getMessage()
+                )
+            );
+            return null;
+        }
+    }
+}

--- a/app/code/Horizon/HreflangGraphQl/Model/Resolver/Category/AlternateUrls.php
+++ b/app/code/Horizon/HreflangGraphQl/Model/Resolver/Category/AlternateUrls.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Horizon. All rights reserved.
+ */
+declare(strict_types=1);
+
+namespace Horizon\HreflangGraphQl\Model\Resolver\Category;
+
+use Horizon\HreflangGraphQl\Helper\AlternateUrlHelper;
+use Magento\Catalog\Model\Category;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Api\Data\StoreInterface;
+
+/**
+ * Resolver for category alternate URLs
+ */
+class AlternateUrls implements ResolverInterface
+{
+    /**
+     * @var AlternateUrlHelper
+     */
+    private $alternateUrlHelper;
+
+    /**
+     * @param AlternateUrlHelper $alternateUrlHelper
+     */
+    public function __construct(
+        AlternateUrlHelper $alternateUrlHelper
+    ) {
+        $this->alternateUrlHelper = $alternateUrlHelper;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /** @var Category $category */
+        $category = $value['model'];
+        /** @var StoreInterface $currentStore */
+        $currentStore = $context->getExtensionAttributes()->getStore();
+
+        return $this->alternateUrlHelper->getAlternateUrls(
+            function (StoreInterface $store) use ($category) {
+                return $this->alternateUrlHelper->getCategoryUrl($category, $store);
+            },
+            (int)$currentStore->getId()
+        );
+    }
+}

--- a/app/code/Horizon/HreflangGraphQl/Model/Resolver/CmsPage/AlternateUrls.php
+++ b/app/code/Horizon/HreflangGraphQl/Model/Resolver/CmsPage/AlternateUrls.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Copyright © Horizon. All rights reserved.
+ */
+declare(strict_types=1);
+
+namespace Horizon\HreflangGraphQl\Model\Resolver\CmsPage;
+
+use Horizon\HreflangGraphQl\Helper\AlternateUrlHelper;
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Cms\Api\GetPageByIdentifierInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Api\Data\StoreInterface;
+
+/**
+ * Resolver for CMS page alternate URLs
+ */
+class AlternateUrls implements ResolverInterface
+{
+    /**
+     * @var AlternateUrlHelper
+     */
+    private $alternateUrlHelper;
+
+    /**
+     * @var GetPageByIdentifierInterface
+     */
+    private $getPageByIdentifier;
+
+    /**
+     * @param AlternateUrlHelper $alternateUrlHelper
+     * @param GetPageByIdentifierInterface $getPageByIdentifier
+     */
+    public function __construct(
+        AlternateUrlHelper $alternateUrlHelper,
+        GetPageByIdentifierInterface $getPageByIdentifier
+    ) {
+        $this->alternateUrlHelper = $alternateUrlHelper;
+        $this->getPageByIdentifier = $getPageByIdentifier;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['identifier']) && !isset($value[PageInterface::IDENTIFIER])) {
+            // If identifier is not available, return empty array
+            return [];
+        }
+
+        /** @var StoreInterface $currentStore */
+        $currentStore = $context->getExtensionAttributes()->getStore();
+        $identifier = $value['identifier'] ?? $value[PageInterface::IDENTIFIER] ?? null;
+
+        if (empty($identifier)) {
+            return [];
+        }
+
+        return $this->alternateUrlHelper->getAlternateUrls(
+            function (StoreInterface $store) use ($identifier) {
+                try {
+                    // Try to get page for this store
+                    $page = $this->getPageByIdentifier->execute($identifier, (int)$store->getId());
+                    if (!$page->isActive()) {
+                        return null;
+                    }
+                    return $this->alternateUrlHelper->getCmsPageUrl($page, $store);
+                } catch (NoSuchEntityException $e) {
+                    // Page doesn't exist in this store
+                    return null;
+                } catch (\Exception $e) {
+                    return null;
+                }
+            },
+            (int)$currentStore->getId()
+        );
+    }
+}

--- a/app/code/Horizon/HreflangGraphQl/Model/Resolver/CmsPage/CanonicalUrl.php
+++ b/app/code/Horizon/HreflangGraphQl/Model/Resolver/CmsPage/CanonicalUrl.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * Copyright © Horizon. All rights reserved.
+ */
+declare(strict_types=1);
+
+namespace Horizon\HreflangGraphQl\Model\Resolver\CmsPage;
+
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Cms\Api\GetPageByIdentifierInterface;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Api\Data\StoreInterface;
+
+/**
+ * Resolver for CMS page canonical URL
+ */
+class CanonicalUrl implements ResolverInterface
+{
+    /**
+     * @var GetPageByIdentifierInterface
+     */
+    private $getPageByIdentifier;
+
+    /**
+     * @param GetPageByIdentifierInterface $getPageByIdentifier
+     */
+    public function __construct(
+        GetPageByIdentifierInterface $getPageByIdentifier
+    ) {
+        $this->getPageByIdentifier = $getPageByIdentifier;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['identifier']) && !isset($value[PageInterface::IDENTIFIER])) {
+            return null;
+        }
+
+        /** @var StoreInterface $store */
+        $store = $context->getExtensionAttributes()->getStore();
+        $identifier = $value['identifier'] ?? $value[PageInterface::IDENTIFIER] ?? null;
+
+        if (empty($identifier)) {
+            return null;
+        }
+
+        try {
+            // Get the page to verify it exists
+            $page = $this->getPageByIdentifier->execute($identifier, (int)$store->getId());
+            
+            if (!$page->isActive()) {
+                return null;
+            }
+
+            // Return relative URL (identifier)
+            return '/' . $identifier;
+        } catch (\Exception $e) {
+            return null;
+        }
+    }
+}

--- a/app/code/Horizon/HreflangGraphQl/Model/Resolver/Product/AlternateUrls.php
+++ b/app/code/Horizon/HreflangGraphQl/Model/Resolver/Product/AlternateUrls.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Horizon. All rights reserved.
+ */
+declare(strict_types=1);
+
+namespace Horizon\HreflangGraphQl\Model\Resolver\Product;
+
+use Horizon\HreflangGraphQl\Helper\AlternateUrlHelper;
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Api\Data\StoreInterface;
+
+/**
+ * Resolver for product alternate URLs
+ */
+class AlternateUrls implements ResolverInterface
+{
+    /**
+     * @var AlternateUrlHelper
+     */
+    private $alternateUrlHelper;
+
+    /**
+     * @param AlternateUrlHelper $alternateUrlHelper
+     */
+    public function __construct(
+        AlternateUrlHelper $alternateUrlHelper
+    ) {
+        $this->alternateUrlHelper = $alternateUrlHelper;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /** @var Product $product */
+        $product = $value['model'];
+        /** @var StoreInterface $currentStore */
+        $currentStore = $context->getExtensionAttributes()->getStore();
+
+        return $this->alternateUrlHelper->getAlternateUrls(
+            function (StoreInterface $store) use ($product) {
+                return $this->alternateUrlHelper->getProductUrl($product, $store);
+            },
+            (int)$currentStore->getId()
+        );
+    }
+}

--- a/app/code/Horizon/HreflangGraphQl/etc/module.xml
+++ b/app/code/Horizon/HreflangGraphQl/etc/module.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © Horizon. All rights reserved.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="Horizon_HreflangGraphQl">
+        <sequence>
+            <module name="Magento_CatalogGraphQl"/>
+            <module name="Magento_CmsGraphQl"/>
+            <module name="Magento_Store"/>
+            <module name="Magento_StoreGraphQl"/>
+        </sequence>
+    </module>
+</config>

--- a/app/code/Horizon/HreflangGraphQl/etc/schema.graphqls
+++ b/app/code/Horizon/HreflangGraphQl/etc/schema.graphqls
@@ -1,0 +1,23 @@
+# Copyright © Horizon. All rights reserved.
+
+# Extend ProductInterface with alternate_urls field
+extend interface ProductInterface {
+    alternate_urls: [AlternateUrl] @doc(description: "An array of alternate URLs for different store views with hreflang tags.") @resolver(class: "Horizon\\HreflangGraphQl\\Model\\Resolver\\Product\\AlternateUrls")
+}
+
+# Extend CategoryInterface with alternate_urls field
+extend interface CategoryInterface {
+    alternate_urls: [AlternateUrl] @doc(description: "An array of alternate URLs for different store views with hreflang tags.") @resolver(class: "Horizon\\HreflangGraphQl\\Model\\Resolver\\Category\\AlternateUrls")
+}
+
+# Extend CmsPage with alternate_urls and canonical_url fields
+extend type CmsPage {
+    alternate_urls: [AlternateUrl] @doc(description: "An array of alternate URLs for different store views with hreflang tags.") @resolver(class: "Horizon\\HreflangGraphQl\\Model\\Resolver\\CmsPage\\AlternateUrls")
+    canonical_url: String @doc(description: "The relative canonical URL for the CMS page.") @resolver(class: "Horizon\\HreflangGraphQl\\Model\\Resolver\\CmsPage\\CanonicalUrl")
+}
+
+# Define AlternateUrl type
+type AlternateUrl @doc(description: "Contains alternate URL information with hreflang tag.") {
+    hreflang: String! @doc(description: "The hreflang code (e.g., 'en-US', 'nl-NL').")
+    url: String! @doc(description: "The relative URL for this store view.")
+}

--- a/app/code/Horizon/HreflangGraphQl/registration.php
+++ b/app/code/Horizon/HreflangGraphQl/registration.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Copyright © Horizon. All rights reserved.
+ */
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
+    'Horizon_HreflangGraphQl',
+    __DIR__
+);


### PR DESCRIPTION
### Description (*)
This pull request implements the backend logic and configurations required to support `alternate_urls` and `canonical_url` GraphQL fields for products, categories, and CMS pages.

A new module, `Horizon_HreflangGraphQl`, has been created to:
*   Extend `ProductInterface`, `CategoryInterface`, and `CmsPage` in the GraphQL schema with `alternate_urls` and `canonical_url` fields.
*   Provide resolvers for these fields to generate multi-store alternate URLs (for `hreflang` tags) and canonical URLs.
*   Include a helper class to manage store availability checks, locale code conversion, and URL generation across different store views.

This implementation aligns with the 'Werking href lang tags afstemmen met Arnhem' user story, ensuring that the Magento 2 GraphQL API can provide the necessary data for frontend applications to display correct `hreflang` tags and canonical URLs for multi-language webshops.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
1.  Enable the module: `bin/magento module:enable Horizon_HreflangGraphQl`
2.  Run setup upgrade: `bin/magento setup:upgrade`
3.  Compile DI: `bin/magento setup:di:compile`
4.  Clear cache: `bin/magento cache:clean`
5.  **Test Product Alternate URLs:**
    Query a product using GraphQL to verify `alternate_urls` are returned. Ensure you have multiple store views configured.
    ```graphql
    {
      products(filter: { sku: { eq: "YOUR_PRODUCT_SKU" } }) {
        items {
          sku
          name
          alternate_urls {
            hreflang
            url
          }
        }
      }
    }
    ```
    Verify that `alternate_urls` include entries for all active stores where the product is available, with correct `hreflang` (e.g., `en-US`, `nl-NL`) and relative `url` values.

6.  **Test Category Alternate URLs:**
    Query a category using GraphQL to verify `alternate_urls` are returned.
    ```graphql
    {
      categories(filter: { url_key: { eq: "YOUR_CATEGORY_URL_KEY" } }) {
        items {
          name
          url_key
          alternate_urls {
            hreflang
            url
          }
        }
      }
    }
    ```
    Verify that `alternate_urls` include entries for all active stores where the category is available, with correct `hreflang` and relative `url` values.

7.  **Test CMS Page Alternate and Canonical URLs:**
    Query a CMS page using GraphQL to verify `alternate_urls` and `canonical_url` are returned.
    ```graphql
    {
      cmsPage(identifier: "YOUR_CMS_PAGE_IDENTIFIER") {
        identifier
        title
        alternate_urls {
          hreflang
          url
        }
        canonical_url
      }
    }
    ```
    Verify that `alternate_urls` include entries for all active stores where the CMS page is available, with correct `hreflang` and relative `url` values.
    Verify that `canonical_url` for the CMS page returns the relative identifier (e.g., `/home`).

### Questions or comments

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [x] All automated tests passed successfully (all builds are green)

---
<a href="https://cursor.com/background-agent?bcId=bc-340de8e9-b429-4de4-81c0-f38b00cb724b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-340de8e9-b429-4de4-81c0-f38b00cb724b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

