### PR TITLE
Refine hreflang implementation for webshop

### DIFF
--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/AlternateUrls.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/AlternateUrls.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Category;
+
+use Magento\Catalog\Model\Category;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\App\Emulation;
+use Magento\CatalogGraphQl\Model\Resolver\Hreflang\HreflangUrlGenerator;
+
+/**
+ * Resolve alternate URLs for category hreflang tags
+ */
+class AlternateUrls implements ResolverInterface
+{
+    /**
+     * @var HreflangUrlGenerator
+     */
+    private $hreflangUrlGenerator;
+
+    /**
+     * @var Emulation
+     */
+    private $appEmulation;
+
+    /**
+     * @param HreflangUrlGenerator $hreflangUrlGenerator
+     * @param Emulation $appEmulation
+     */
+    public function __construct(
+        HreflangUrlGenerator $hreflangUrlGenerator,
+        Emulation $appEmulation
+    ) {
+        $this->hreflangUrlGenerator = $hreflangUrlGenerator;
+        $this->appEmulation = $appEmulation;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /* @var Category $category */
+        $category = $value['model'];
+        /** @var StoreInterface $store */
+        $store = $context->getExtensionAttributes()->getStore();
+
+        // Generate alternate URLs for all stores
+        $alternateUrls = $this->hreflangUrlGenerator->generateAlternateUrls(
+            function (StoreInterface $targetStore) use ($category) {
+                try {
+                    // Emulate store environment for URL generation
+                    $this->appEmulation->startEnvironmentEmulation(
+                        (int)$targetStore->getId(),
+                        \Magento\Framework\App\Area::AREA_FRONTEND,
+                        true
+                    );
+                    
+                    // Generate URL for this store
+                    $baseUrl = $category->getUrlInstance()->getBaseUrl();
+                    $categoryUrl = $category->getUrl();
+                    
+                    if (!$categoryUrl) {
+                        return null;
+                    }
+
+                    // Return relative URL
+                    return str_replace($baseUrl, '', $categoryUrl);
+                } catch (\Exception $e) {
+                    return null;
+                } finally {
+                    // Stop store emulation
+                    $this->appEmulation->stopEnvironmentEmulation();
+                }
+            },
+            $store
+        );
+
+        // Return as JSON string for frontend consumption
+        return json_encode($alternateUrls);
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Hreflang.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Category/Hreflang.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Category;
+
+use Magento\Catalog\Model\Category;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\CatalogGraphQl\Model\Resolver\Hreflang\HreflangUrlGenerator;
+
+/**
+ * Resolve data for category hreflang tag
+ */
+class Hreflang implements ResolverInterface
+{
+    /**
+     * @var HreflangUrlGenerator
+     */
+    private $hreflangUrlGenerator;
+
+    /**
+     * @param HreflangUrlGenerator $hreflangUrlGenerator
+     */
+    public function __construct(HreflangUrlGenerator $hreflangUrlGenerator)
+    {
+        $this->hreflangUrlGenerator = $hreflangUrlGenerator;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /* @var Category $category */
+        $category = $value['model'];
+        /** @var StoreInterface $store */
+        $store = $context->getExtensionAttributes()->getStore();
+
+        return $this->hreflangUrlGenerator->getCurrentHreflang($store);
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Hreflang/HreflangUrlGenerator.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Hreflang/HreflangUrlGenerator.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Hreflang;
+
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\Framework\Locale\ResolverInterface as LocaleResolverInterface;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Api\Data\StoreInterface;
+
+/**
+ * Helper class to generate hreflang alternate URLs
+ */
+class HreflangUrlGenerator
+{
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var LocaleResolverInterface
+     */
+    private $localeResolver;
+
+    /**
+     * @var UrlInterface
+     */
+    private $urlBuilder;
+
+    /**
+     * @param StoreManagerInterface $storeManager
+     * @param LocaleResolverInterface $localeResolver
+     * @param UrlInterface $urlBuilder
+     */
+    public function __construct(
+        StoreManagerInterface $storeManager,
+        LocaleResolverInterface $localeResolver,
+        UrlInterface $urlBuilder
+    ) {
+        $this->storeManager = $storeManager;
+        $this->localeResolver = $localeResolver;
+        $this->urlBuilder = $urlBuilder;
+    }
+
+    /**
+     * Generate alternate URLs for all stores
+     *
+     * @param callable $urlGenerator Callback that generates URL for a given store
+     * @param StoreInterface $currentStore Current store
+     * @return array Array of alternate URLs with structure: [['hreflang' => 'en', 'url' => '/path'], ...]
+     */
+    public function generateAlternateUrls(callable $urlGenerator, StoreInterface $currentStore): array
+    {
+        $alternateUrls = [];
+        $stores = $this->storeManager->getStores(true);
+
+        foreach ($stores as $store) {
+            if (!$store->isActive()) {
+                continue;
+            }
+
+            try {
+                $storeId = (int)$store->getId();
+                $currentStoreId = (int)$currentStore->getId();
+
+                // Generate URL for this store
+                $url = $urlGenerator($store);
+                if (!$url) {
+                    continue;
+                }
+
+                // Get locale code for this store
+                $locale = $this->getLocaleForStore($store);
+                $hreflang = $this->normalizeLocale($locale);
+
+                // Ensure URL is absolute
+                $absoluteUrl = $this->makeAbsoluteUrl($url, $store);
+
+                $alternateUrls[] = [
+                    'hreflang' => $hreflang,
+                    'url' => $absoluteUrl
+                ];
+            } catch (\Exception $e) {
+                // Skip stores that fail to generate URLs
+                continue;
+            }
+        }
+
+        return $alternateUrls;
+    }
+
+    /**
+     * Get current page hreflang value
+     *
+     * @param StoreInterface $store
+     * @return string
+     */
+    public function getCurrentHreflang(StoreInterface $store): string
+    {
+        $locale = $this->getLocaleForStore($store);
+        return $this->normalizeLocale($locale);
+    }
+
+    /**
+     * Get locale for a store
+     *
+     * @param StoreInterface $store
+     * @return string
+     */
+    private function getLocaleForStore(StoreInterface $store): string
+    {
+        // Try to get locale from store config
+        $locale = $store->getConfig('general/locale/code');
+        if (!$locale) {
+            // Fallback to store locale code if method exists
+            if (method_exists($store, 'getLocaleCode')) {
+                $locale = $store->getLocaleCode();
+            }
+        }
+        if (!$locale) {
+            // Final fallback
+            $locale = 'en_US';
+        }
+        return $locale;
+    }
+
+    /**
+     * Normalize locale to hreflang format (e.g., 'en_US' -> 'en', 'nl_NL' -> 'nl')
+     *
+     * @param string $locale
+     * @return string
+     */
+    private function normalizeLocale(string $locale): string
+    {
+        // Extract language code from locale (e.g., 'en_US' -> 'en')
+        $parts = explode('_', $locale);
+        return strtolower($parts[0] ?? 'en');
+    }
+
+    /**
+     * Make URL absolute if it's relative
+     *
+     * @param string $url
+     * @param StoreInterface $store
+     * @return string
+     */
+    private function makeAbsoluteUrl(string $url, StoreInterface $store): string
+    {
+        // If URL is already absolute, return as is
+        if (preg_match('/^https?:\/\//', $url)) {
+            return $url;
+        }
+
+        // Get base URL for the store
+        $baseUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_LINK);
+        
+        // Remove trailing slash from base URL and leading slash from path
+        $baseUrl = rtrim($baseUrl, '/');
+        $url = ltrim($url, '/');
+
+        return $baseUrl . '/' . $url;
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/AlternateUrls.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/AlternateUrls.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Product;
+
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\Store\Model\App\Emulation;
+use Magento\CatalogGraphQl\Model\Resolver\Hreflang\HreflangUrlGenerator;
+
+/**
+ * Resolve alternate URLs for product hreflang tags
+ */
+class AlternateUrls implements ResolverInterface
+{
+    /**
+     * @var HreflangUrlGenerator
+     */
+    private $hreflangUrlGenerator;
+
+    /**
+     * @var Emulation
+     */
+    private $appEmulation;
+
+    /**
+     * @param HreflangUrlGenerator $hreflangUrlGenerator
+     * @param Emulation $appEmulation
+     */
+    public function __construct(
+        HreflangUrlGenerator $hreflangUrlGenerator,
+        Emulation $appEmulation
+    ) {
+        $this->hreflangUrlGenerator = $hreflangUrlGenerator;
+        $this->appEmulation = $appEmulation;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /* @var Product $product */
+        $product = $value['model'];
+        /** @var StoreInterface $store */
+        $store = $context->getExtensionAttributes()->getStore();
+
+        // Generate alternate URLs for all stores
+        $alternateUrls = $this->hreflangUrlGenerator->generateAlternateUrls(
+            function (StoreInterface $targetStore) use ($product) {
+                try {
+                    // Emulate store environment for URL generation
+                    $this->appEmulation->startEnvironmentEmulation(
+                        (int)$targetStore->getId(),
+                        \Magento\Framework\App\Area::AREA_FRONTEND,
+                        true
+                    );
+                    
+                    // Generate URL for this store
+                    $product->getUrlModel()->getUrl($product, ['_ignore_category' => true]);
+                    $requestPath = $product->getRequestPath();
+                    
+                    if (!$requestPath) {
+                        return null;
+                    }
+
+                    return $requestPath;
+                } catch (\Exception $e) {
+                    return null;
+                } finally {
+                    // Stop store emulation
+                    $this->appEmulation->stopEnvironmentEmulation();
+                }
+            },
+            $store
+        );
+
+        // Return as JSON string for frontend consumption
+        return json_encode($alternateUrls);
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/Hreflang.php
+++ b/app/code/Magento/CatalogGraphQl/Model/Resolver/Product/Hreflang.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CatalogGraphQl\Model\Resolver\Product;
+
+use Magento\Catalog\Model\Product;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Store\Api\Data\StoreInterface;
+use Magento\CatalogGraphQl\Model\Resolver\Hreflang\HreflangUrlGenerator;
+
+/**
+ * Resolve data for product hreflang tag
+ */
+class Hreflang implements ResolverInterface
+{
+    /**
+     * @var HreflangUrlGenerator
+     */
+    private $hreflangUrlGenerator;
+
+    /**
+     * @param HreflangUrlGenerator $hreflangUrlGenerator
+     */
+    public function __construct(HreflangUrlGenerator $hreflangUrlGenerator)
+    {
+        $this->hreflangUrlGenerator = $hreflangUrlGenerator;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value['model'])) {
+            throw new LocalizedException(__('"model" value should be specified'));
+        }
+
+        /* @var Product $product */
+        $product = $value['model'];
+        /** @var StoreInterface $store */
+        $store = $context->getExtensionAttributes()->getStore();
+
+        return $this->hreflangUrlGenerator->getCurrentHreflang($store);
+    }
+}

--- a/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CatalogGraphQl/etc/schema.graphqls
@@ -124,6 +124,8 @@ interface ProductInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model\
     manufacturer: Int @doc(description: "A number representing the product's manufacturer.")
     categories: [CategoryInterface] @doc(description: "The categories assigned to a product.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Categories") @cache(cacheIdentity: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CategoriesIdentity")
     canonical_url: String @doc(description: "The relative canonical URL. This value is returned only if the system setting 'Use Canonical Link Meta Tag For Products' is enabled.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\CanonicalUrl")
+    hreflang: String @doc(description: "The hreflang value for the current page locale (e.g., 'en', 'nl').") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\Hreflang")
+    alternate_urls: String @doc(description: "JSON string containing alternate URLs for hreflang tags. Format: [{\"hreflang\": \"en\", \"url\": \"https://example.com/path\"}, ...]") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\AlternateUrls")
     media_gallery: [MediaGalleryInterface] @doc(description: "An array of media gallery objects.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\MediaGallery")
     custom_attributesV2(filters: AttributeFilterInput): ProductCustomAttributes @doc(description: "Product custom attributes.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Product\\ProductCustomAttributes")
 }
@@ -260,6 +262,8 @@ interface CategoryInterface @typeResolver(class: "Magento\\CatalogGraphQl\\Model
     url_key: String @doc(description: "The URL key assigned to the category.")
     url_path: String @doc(description: "The URL path assigned to the category.")
     canonical_url: String @doc(description: "The relative canonical URL. This value is returned only if the system setting 'Use Canonical Link Meta Tag For Categories' is enabled.") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\CanonicalUrl")
+    hreflang: String @doc(description: "The hreflang value for the current page locale (e.g., 'en', 'nl').") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\Hreflang")
+    alternate_urls: String @doc(description: "JSON string containing alternate URLs for hreflang tags. Format: [{\"hreflang\": \"en\", \"url\": \"https://example.com/path\"}, ...]") @resolver(class: "Magento\\CatalogGraphQl\\Model\\Resolver\\Category\\AlternateUrls")
     position: Int @doc(description: "The position of the category relative to other categories at the same level in tree.")
     level: Int @doc(description: "The depth of the category within the tree.")
     created_at: String @deprecated(reason: "The field should not be used on the storefront.") @doc(description: "The timestamp indicating when the category was created.")


### PR DESCRIPTION
### Description (*)
This PR implements backend support for `hreflang` tags within the Magento GraphQL API for products and categories.

**Key Changes:**
*   **New `HreflangUrlGenerator` helper class:** Responsible for generating alternate URLs across all active stores, retrieving locale codes, normalizing them to `hreflang` format (e.g., 'en_US' to 'en'), and ensuring absolute URLs.
*   **New GraphQL Resolvers:**
    *   `Product/Hreflang.php` and `Category/Hreflang.php`: Provide the `hreflang` value for the current page's locale.
    *   `Product/AlternateUrls.php` and `Category/AlternateUrls.php`: Return a JSON string containing alternate URLs for the respective entity across all active stores, including their `hreflang` values.
*   **`schema.graphqls` update:** Adds `hreflang: String` and `alternate_urls: String` fields to `ProductInterface` and `CategoryInterface`.
*   **Store Emulation:** Ensures correct URL generation by emulating the environment of each target store.
*   **Error Handling:** Gracefully handles cases where products or categories may not exist in certain stores.

This enhancement allows the frontend to query for `hreflang` and `alternate_urls` to render appropriate meta tags for multilingual SEO.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
1.  **Configure Multiple Stores/Locales:** Ensure your Magento instance has multiple active stores configured with different locales (e.g., `en_US`, `nl_NL`).
2.  **Create/Assign Content:** Create a product and a category, ensuring they are assigned to multiple stores.
3.  **Query Product Hreflang Data:**
    *   Execute a GraphQL query for a product, requesting the new `hreflang` and `alternate_urls` fields.
    *   Example:
        ```graphql
        query {
          products(filter: {sku: {eq: "YOUR_PRODUCT_SKU"}}) {
            items {
              name
              hreflang
              alternate_urls
            }
          }
        }
        ```
    *   Verify that `hreflang` returns the correct language code (e.g., "en", "nl") for the current store context.
    *   Verify that `alternate_urls` returns a valid JSON string containing an array of objects, each with `hreflang` and an absolute `url` for the product in all active stores.
4.  **Query Category Hreflang Data:**
    *   Execute a GraphQL query for a category, requesting the new `hreflang` and `alternate_urls` fields.
    *   Example:
        ```graphql
        query {
          categories(filters: {url_key: {eq: "YOUR_CATEGORY_URL_KEY"}}) {
            items {
              name
              hreflang
              alternate_urls
            }
          }
        }
        ```
    *   Verify the `hreflang` and `alternate_urls` output as described in step 3 for categories.
5.  **Test Missing Content:** If a product/category is not assigned to a specific store, ensure that the `alternate_urls` JSON correctly omits an entry for that store, or handles it gracefully without errors.

### Questions or comments
None.

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

---
<a href="https://cursor.com/background-agent?bcId=bc-620b1e28-f6ee-4097-97df-d99e23877206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-620b1e28-f6ee-4097-97df-d99e23877206"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

