### PR TITLE
Update backend for absolute hreflang alternate urls

### DIFF
--- a/app/code/Magento/CmsGraphQl/Model/Resolver/Page/AlternateUrls.php
+++ b/app/code/Magento/CmsGraphQl/Model/Resolver/Page/AlternateUrls.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Magento\CmsGraphQl\Model\Resolver\Page;
+
+use Magento\Cms\Api\Data\PageInterface;
+use Magento\Cms\Api\PageRepositoryInterface;
+use Magento\CmsUrlRewrite\Model\CmsPageUrlPathGenerator;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\GraphQl\Config\Element\Field;
+use Magento\Framework\GraphQl\Query\ResolverInterface;
+use Magento\Framework\GraphQl\Schema\Type\ResolveInfo;
+use Magento\Framework\UrlInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Magento\UrlRewrite\Model\UrlFinderInterface;
+use Magento\UrlRewrite\Service\V1\Data\UrlRewrite;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Resolver for alternate URLs field to provide hreflang tag data
+ */
+class AlternateUrls implements ResolverInterface
+{
+    /**
+     * Locale config path
+     */
+    private const XML_PATH_DEFAULT_LOCALE = 'general/locale/code';
+
+    /**
+     * CMS page entity type
+     */
+    private const ENTITY_TYPE = 'cms-page';
+
+    /**
+     * @var PageRepositoryInterface
+     */
+    private $pageRepository;
+
+    /**
+     * @var StoreManagerInterface
+     */
+    private $storeManager;
+
+    /**
+     * @var CmsPageUrlPathGenerator
+     */
+    private $urlPathGenerator;
+
+    /**
+     * @var UrlFinderInterface
+     */
+    private $urlFinder;
+
+    /**
+     * @var ScopeConfigInterface
+     */
+    private $scopeConfig;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @param PageRepositoryInterface $pageRepository
+     * @param StoreManagerInterface $storeManager
+     * @param CmsPageUrlPathGenerator $urlPathGenerator
+     * @param UrlFinderInterface $urlFinder
+     * @param ScopeConfigInterface $scopeConfig
+     * @param LoggerInterface $logger
+     */
+    public function __construct(
+        PageRepositoryInterface $pageRepository,
+        StoreManagerInterface $storeManager,
+        CmsPageUrlPathGenerator $urlPathGenerator,
+        UrlFinderInterface $urlFinder,
+        ScopeConfigInterface $scopeConfig,
+        LoggerInterface $logger
+    ) {
+        $this->pageRepository = $pageRepository;
+        $this->storeManager = $storeManager;
+        $this->urlPathGenerator = $urlPathGenerator;
+        $this->urlFinder = $urlFinder;
+        $this->scopeConfig = $scopeConfig;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function resolve(
+        Field $field,
+        $context,
+        ResolveInfo $info,
+        array $value = null,
+        array $args = null
+    ) {
+        if (!isset($value[PageInterface::PAGE_ID])) {
+            $this->logger->warning('CMS Page alternate_urls resolver: page_id not found in value array');
+            return json_encode([]);
+        }
+
+        $pageId = (int)$value[PageInterface::PAGE_ID];
+
+        try {
+            $page = $this->pageRepository->getById($pageId);
+        } catch (NoSuchEntityException $e) {
+            $this->logger->error('CMS Page alternate_urls resolver: Page not found', ['page_id' => $pageId]);
+            return json_encode([]);
+        }
+
+        $alternateUrls = [];
+        $stores = $page->getStores();
+
+        // If stores array contains 0, it means the page is available for all stores
+        if (in_array('0', $stores, true) || in_array(0, $stores, true)) {
+            $stores = array_keys($this->storeManager->getStores());
+        }
+
+        foreach ($stores as $storeId) {
+            try {
+                $store = $this->storeManager->getStore((int)$storeId);
+                
+                // Get locale code for hreflang tag
+                $localeCode = $this->scopeConfig->getValue(
+                    self::XML_PATH_DEFAULT_LOCALE,
+                    ScopeInterface::SCOPE_STORE,
+                    $store->getCode()
+                );
+                
+                // Find URL rewrite for this page in this store to get the correct request path
+                $urlRewrite = $this->urlFinder->findOneByData([
+                    UrlRewrite::ENTITY_TYPE => self::ENTITY_TYPE,
+                    UrlRewrite::ENTITY_ID => $pageId,
+                    UrlRewrite::STORE_ID => $store->getId(),
+                    UrlRewrite::REDIRECT_TYPE => 0
+                ]);
+                
+                // Use request path from URL rewrite if available, otherwise fall back to identifier
+                $requestPath = $urlRewrite ? $urlRewrite->getRequestPath() : $this->urlPathGenerator->getUrlPath($page);
+                
+                // Generate absolute URL for this store
+                $baseUrl = $store->getBaseUrl(UrlInterface::URL_TYPE_WEB, true);
+                
+                // Ensure URL is absolute and complete
+                $absoluteUrl = rtrim($baseUrl, '/') . '/' . ltrim($requestPath, '/');
+                
+                // Use locale code as key (e.g., "en_US", "nl_NL")
+                $alternateUrls[$localeCode] = $absoluteUrl;
+            } catch (NoSuchEntityException $e) {
+                $this->logger->warning(
+                    'CMS Page alternate_urls resolver: Store not found',
+                    ['store_id' => $storeId, 'page_id' => $pageId]
+                );
+                continue;
+            } catch (\Exception $e) {
+                $this->logger->error(
+                    'CMS Page alternate_urls resolver: Error generating URL for store',
+                    ['store_id' => $storeId, 'page_id' => $pageId, 'error' => $e->getMessage()]
+                );
+                continue;
+            }
+        }
+
+        return json_encode($alternateUrls, JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/app/code/Magento/CmsGraphQl/etc/schema.graphqls
+++ b/app/code/Magento/CmsGraphQl/etc/schema.graphqls
@@ -30,6 +30,7 @@ type CmsPage implements RoutableInterface @doc(description: "Contains details ab
     meta_title: String @doc(description: "A page title that is indexed by search engines and appears in search results listings.")
     meta_description: String @doc(description: "A brief description of the page for search results listings.")
     meta_keywords: String @doc(description: "A brief description of the page for search results listings.")
+    alternate_urls: String @resolver(class: "Magento\\CmsGraphQl\\Model\\Resolver\\Page\\AlternateUrls") @doc(description: "JSON string containing alternate URLs for hreflang tags. Format: {\"locale\": \"absolute_url\"}. All URLs are absolute and complete.")
 }
 
 type CmsBlocks @doc(description: "Contains an array CMS block items.") {


### PR DESCRIPTION
### Description (*)
This PR implements backend support for `alternate_urls` in the Magento 2 CMS GraphQL API, providing complete and absolute URLs for hreflang tags. This aligns with frontend requirements for SEO compliance and Happy Horizon Arnhem's specifications.

The changes include:
-   **GraphQL Schema Update**: Added an `alternate_urls` field to the `CmsPage` type in `app/code/Magento/CmsGraphQl/etc/schema.graphqls`. This field returns a JSON string mapping locale codes to absolute URLs.
-   **New Resolver**: Created `app/code/Magento/CmsGraphQl/Model/Resolver/Page/AlternateUrls.php`. This resolver:
    -   Retrieves the CMS page and its associated stores.
    -   For each store, it determines the locale code and generates an absolute URL using URL rewrites (or page identifier as fallback) and the store's base URL.
    -   Returns a JSON string of locale-to-absolute-URL mappings, ensuring all URLs are complete with protocol and domain.
    -   Includes robust error handling and logging for missing pages, stores, or URL rewrites.

### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
1. Fixes magento/magento2#<issue_number>

### Manual testing scenarios (*)
1.  **Create a CMS Page**: Create a new CMS page in the Magento Admin.
2.  **Assign to Multiple Stores**: Assign this CMS page to several store views, each configured with a different locale (e.g., `en_US`, `nl_NL`). Ensure URL rewrites are generated for these pages in each store view.
3.  **Query GraphQL**: Execute a GraphQL query for the created CMS page, requesting the `alternate_urls` field:
    ```graphql
    query {
      cmsPage(identifier: "your-page-identifier") {
        identifier
        title
        alternate_urls
      }
    }
    ```
4.  **Verify Output**:
    *   Confirm that the `alternate_urls` field is present in the response.
    *   Verify that the JSON string contains entries for each assigned store's locale code, with complete and absolute URLs (including protocol and domain).
    *   Example expected output: `{"en_US": "https://example.com/en/your-page-identifier", "nl_NL": "https://example.com/nl/your-page-identifier"}`
5.  **Test "All Store Views"**: Create a CMS page and assign it to "All Store Views". Repeat steps 3 and 4, ensuring `alternate_urls` includes entries for all active store views.
6.  **Test Fallback**: Create a CMS page without a specific URL rewrite (if possible, or simulate by checking a page that might only use its identifier). Verify the `alternate_urls` still generates a correct absolute URL based on the page identifier.
7.  **Test Non-existent Page**: Query for a `cmsPage` with a non-existent identifier. The `alternate_urls` field should return an empty JSON string (`{}`).

### Questions or comments
None.

### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)

---
<a href="https://cursor.com/background-agent?bcId=bc-31366a52-f352-439d-8785-17acd108dbdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-31366a52-f352-439d-8785-17acd108dbdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

